### PR TITLE
Fix mobile menu toggle

### DIFF
--- a/style.css
+++ b/style.css
@@ -146,6 +146,7 @@ footer {
   }
 
   nav {
+    display: none;
     position: absolute;
     top: 100%;
     left: 0;
@@ -160,6 +161,7 @@ footer {
   }
 
   nav.open {
+    display: flex;
     transform: translateY(0);
   }
 


### PR DESCRIPTION
## Summary
- hide navigation menu by default on small screens
- show menu when `open` class is active

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68875cc0ecb08332ac2ed0bf192d5b99