### PR TITLE
Hide success message on contact page load

### DIFF
--- a/script.js
+++ b/script.js
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const success = document.getElementById('success');
   if (success) {
+    success.style.display = 'none';
     const urlParams = new URLSearchParams(window.location.search);
     if (urlParams.get('success') === '1') {
       success.style.display = 'block';

--- a/style.css
+++ b/style.css
@@ -125,6 +125,7 @@ section {
 }
 
 .success-message {
+  display: none; /* verborgen tot bevestiging */
   background-color: #e0fbe0;
   color: #145214;
   padding: 1em;


### PR DESCRIPTION
## Summary
- hide the thank-you success message by default in the CSS
- explicitly hide the message on page load in `script.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68875f6ecaa4833295496ff40e71a9c4