### PR TITLE
Fix success message behavior

### DIFF
--- a/script.js
+++ b/script.js
@@ -15,6 +15,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const urlParams = new URLSearchParams(window.location.search);
     if (urlParams.get('success') === '1') {
       success.style.display = 'block';
+
+      // remove ?success=1 from the URL so the message is not shown on refresh
+      const url = new URL(window.location);
+      url.searchParams.delete('success');
+      history.replaceState(null, '', url);
+
+      // hide the message after a short delay
+      setTimeout(() => {
+        success.style.display = 'none';
+      }, 5000);
     }
   }
 });


### PR DESCRIPTION
## Summary
- hide the contact form success message after a short delay
- remove the `success` query parameter after displaying the message

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887606852e4833284106ecd2746f651