### PR TITLE
Add auto-collapse to mobile menu

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,11 +2,41 @@ document.addEventListener('DOMContentLoaded', () => {
   const toggle = document.querySelector('.menu-toggle');
   const nav = document.querySelector('nav');
   if (toggle && nav) {
+    const closeMenu = () => {
+      nav.classList.remove('open');
+      toggle.setAttribute('aria-expanded', false);
+    };
+
+    const isMobile = () => window.getComputedStyle(toggle).display !== 'none';
+
     toggle.addEventListener('click', () => {
       nav.classList.toggle('open');
       const expanded = nav.classList.contains('open');
       toggle.setAttribute('aria-expanded', expanded);
     });
+
+    const collapseOnInteraction = (e) => {
+      if (
+        isMobile() &&
+        nav.classList.contains('open') &&
+        !nav.contains(e.target) &&
+        e.target !== toggle
+      ) {
+        closeMenu();
+      }
+    };
+
+    document.addEventListener('click', collapseOnInteraction);
+    document.addEventListener('keydown', () => {
+      if (isMobile() && nav.classList.contains('open')) {
+        closeMenu();
+      }
+    });
+    document.addEventListener('scroll', () => {
+      if (isMobile() && nav.classList.contains('open')) {
+        closeMenu();
+      }
+    }, { passive: true });
   }
 
   const success = document.getElementById('success');


### PR DESCRIPTION
## Summary
- close mobile menu when clicking, scrolling or typing outside of it

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688777b5dbec8332838f9c903622c164