### PR TITLE
Adjust nav markup and sticky footer

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -20,16 +20,7 @@
     </div>
     <nav id="main-nav">
       <div class="container">
-        <ul>
-          <li><a href="index.html">Home</a></li>
-          <li><a href="licht-geluid-op-locatie.html">Licht &amp; Geluid</a></li>
-          <li><a href="technische-ondersteuning.html">Technische Ondersteuning</a></li>
-          <li><a href="stroomvoorziening-op-locatie.html">Stroomvoorziening</a></li>
-          <li><a href="materiaal-verhuur.html">Materiaal Verhuur</a></li>
-          <li><a href="spoedservice.html">Spoedservice</a></li>
-          <li><a href="contact.html">Contact</a></li>
-          <li><a href="facebook.html">Facebook</a></li>
-        </ul>
+        <ul><li><a href="index.html">Home</a></li><li><a href="licht-geluid-op-locatie.html">Licht &amp; Geluid</a></li><li><a href="technische-ondersteuning.html">Technische Ondersteuning</a></li><li><a href="stroomvoorziening-op-locatie.html">Stroomvoorziening</a></li><li><a href="materiaal-verhuur.html">Materiaal Verhuur</a></li><li><a href="spoedservice.html">Spoedservice</a></li><li><a href="contact.html">Contact</a></li><li><a href="facebook.html">Facebook</a></li></ul>
       </div>
     </nav>
   </header>

--- a/facebook.html
+++ b/facebook.html
@@ -19,16 +19,7 @@
     </div>
     <nav id="main-nav">
       <div class="container">
-        <ul>
-          <li><a href="index.html">Home</a></li>
-          <li><a href="licht-geluid-op-locatie.html">Licht &amp; Geluid</a></li>
-          <li><a href="technische-ondersteuning.html">Technische Ondersteuning</a></li>
-          <li><a href="stroomvoorziening-op-locatie.html">Stroomvoorziening</a></li>
-          <li><a href="materiaal-verhuur.html">Materiaal Verhuur</a></li>
-          <li><a href="spoedservice.html">Spoedservice</a></li>
-          <li><a href="contact.html">Contact</a></li>
-          <li><a href="facebook.html">Facebook</a></li>
-        </ul>
+        <ul><li><a href="index.html">Home</a></li><li><a href="licht-geluid-op-locatie.html">Licht &amp; Geluid</a></li><li><a href="technische-ondersteuning.html">Technische Ondersteuning</a></li><li><a href="stroomvoorziening-op-locatie.html">Stroomvoorziening</a></li><li><a href="materiaal-verhuur.html">Materiaal Verhuur</a></li><li><a href="spoedservice.html">Spoedservice</a></li><li><a href="contact.html">Contact</a></li><li><a href="facebook.html">Facebook</a></li></ul>
       </div>
     </nav>
   </header>

--- a/index.html
+++ b/index.html
@@ -19,16 +19,7 @@
     </div>
     <nav id="main-nav">
       <div class="container">
-        <ul>
-          <li><a href="index.html">Home</a></li>
-          <li><a href="licht-geluid-op-locatie.html">Licht &amp; Geluid</a></li>
-          <li><a href="technische-ondersteuning.html">Technische Ondersteuning</a></li>
-          <li><a href="stroomvoorziening-op-locatie.html">Stroomvoorziening</a></li>
-          <li><a href="materiaal-verhuur.html">Materiaal Verhuur</a></li>
-          <li><a href="spoedservice.html">Spoedservice</a></li>
-          <li><a href="contact.html">Contact</a></li>
-          <li><a href="facebook.html">Facebook</a></li>
-        </ul>
+        <ul><li><a href="index.html">Home</a></li><li><a href="licht-geluid-op-locatie.html">Licht &amp; Geluid</a></li><li><a href="technische-ondersteuning.html">Technische Ondersteuning</a></li><li><a href="stroomvoorziening-op-locatie.html">Stroomvoorziening</a></li><li><a href="materiaal-verhuur.html">Materiaal Verhuur</a></li><li><a href="spoedservice.html">Spoedservice</a></li><li><a href="contact.html">Contact</a></li><li><a href="facebook.html">Facebook</a></li></ul>
       </div>
     </nav>
   </header>

--- a/licht-geluid-op-locatie.html
+++ b/licht-geluid-op-locatie.html
@@ -19,16 +19,7 @@
     </div>
     <nav id="main-nav">
       <div class="container">
-        <ul>
-          <li><a href="index.html">Home</a></li>
-          <li><a href="licht-geluid-op-locatie.html">Licht &amp; Geluid</a></li>
-          <li><a href="technische-ondersteuning.html">Technische Ondersteuning</a></li>
-          <li><a href="stroomvoorziening-op-locatie.html">Stroomvoorziening</a></li>
-          <li><a href="materiaal-verhuur.html">Materiaal Verhuur</a></li>
-          <li><a href="spoedservice.html">Spoedservice</a></li>
-          <li><a href="contact.html">Contact</a></li>
-          <li><a href="facebook.html">Facebook</a></li>
-        </ul>
+        <ul><li><a href="index.html">Home</a></li><li><a href="licht-geluid-op-locatie.html">Licht &amp; Geluid</a></li><li><a href="technische-ondersteuning.html">Technische Ondersteuning</a></li><li><a href="stroomvoorziening-op-locatie.html">Stroomvoorziening</a></li><li><a href="materiaal-verhuur.html">Materiaal Verhuur</a></li><li><a href="spoedservice.html">Spoedservice</a></li><li><a href="contact.html">Contact</a></li><li><a href="facebook.html">Facebook</a></li></ul>
       </div>
     </nav>
   </header>

--- a/materiaal-verhuur.html
+++ b/materiaal-verhuur.html
@@ -19,16 +19,7 @@
     </div>
     <nav id="main-nav">
       <div class="container">
-        <ul>
-          <li><a href="index.html">Home</a></li>
-          <li><a href="licht-geluid-op-locatie.html">Licht &amp; Geluid</a></li>
-          <li><a href="technische-ondersteuning.html">Technische Ondersteuning</a></li>
-          <li><a href="stroomvoorziening-op-locatie.html">Stroomvoorziening</a></li>
-          <li><a href="materiaal-verhuur.html">Materiaal Verhuur</a></li>
-          <li><a href="spoedservice.html">Spoedservice</a></li>
-          <li><a href="contact.html">Contact</a></li>
-          <li><a href="facebook.html">Facebook</a></li>
-        </ul>
+        <ul><li><a href="index.html">Home</a></li><li><a href="licht-geluid-op-locatie.html">Licht &amp; Geluid</a></li><li><a href="technische-ondersteuning.html">Technische Ondersteuning</a></li><li><a href="stroomvoorziening-op-locatie.html">Stroomvoorziening</a></li><li><a href="materiaal-verhuur.html">Materiaal Verhuur</a></li><li><a href="spoedservice.html">Spoedservice</a></li><li><a href="contact.html">Contact</a></li><li><a href="facebook.html">Facebook</a></li></ul>
       </div>
     </nav>
   </header>

--- a/spoedservice.html
+++ b/spoedservice.html
@@ -19,16 +19,7 @@
     </div>
     <nav id="main-nav">
       <div class="container">
-        <ul>
-          <li><a href="index.html">Home</a></li>
-          <li><a href="licht-geluid-op-locatie.html">Licht &amp; Geluid</a></li>
-          <li><a href="technische-ondersteuning.html">Technische Ondersteuning</a></li>
-          <li><a href="stroomvoorziening-op-locatie.html">Stroomvoorziening</a></li>
-          <li><a href="materiaal-verhuur.html">Materiaal Verhuur</a></li>
-          <li><a href="spoedservice.html">Spoedservice</a></li>
-          <li><a href="contact.html">Contact</a></li>
-          <li><a href="facebook.html">Facebook</a></li>
-        </ul>
+        <ul><li><a href="index.html">Home</a></li><li><a href="licht-geluid-op-locatie.html">Licht &amp; Geluid</a></li><li><a href="technische-ondersteuning.html">Technische Ondersteuning</a></li><li><a href="stroomvoorziening-op-locatie.html">Stroomvoorziening</a></li><li><a href="materiaal-verhuur.html">Materiaal Verhuur</a></li><li><a href="spoedservice.html">Spoedservice</a></li><li><a href="contact.html">Contact</a></li><li><a href="facebook.html">Facebook</a></li></ul>
       </div>
     </nav>
   </header>

--- a/stroomvoorziening-op-locatie.html
+++ b/stroomvoorziening-op-locatie.html
@@ -19,16 +19,7 @@
     </div>
     <nav id="main-nav">
       <div class="container">
-        <ul>
-          <li><a href="index.html">Home</a></li>
-          <li><a href="licht-geluid-op-locatie.html">Licht &amp; Geluid</a></li>
-          <li><a href="technische-ondersteuning.html">Technische Ondersteuning</a></li>
-          <li><a href="stroomvoorziening-op-locatie.html">Stroomvoorziening</a></li>
-          <li><a href="materiaal-verhuur.html">Materiaal Verhuur</a></li>
-          <li><a href="spoedservice.html">Spoedservice</a></li>
-          <li><a href="contact.html">Contact</a></li>
-          <li><a href="facebook.html">Facebook</a></li>
-        </ul>
+        <ul><li><a href="index.html">Home</a></li><li><a href="licht-geluid-op-locatie.html">Licht &amp; Geluid</a></li><li><a href="technische-ondersteuning.html">Technische Ondersteuning</a></li><li><a href="stroomvoorziening-op-locatie.html">Stroomvoorziening</a></li><li><a href="materiaal-verhuur.html">Materiaal Verhuur</a></li><li><a href="spoedservice.html">Spoedservice</a></li><li><a href="contact.html">Contact</a></li><li><a href="facebook.html">Facebook</a></li></ul>
       </div>
     </nav>
   </header>

--- a/style.css
+++ b/style.css
@@ -4,6 +4,9 @@ body {
   color: #222;
   margin: 0;
   line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 .container {
@@ -44,6 +47,8 @@ header .container {
   gap: 1.5rem;
   margin: 0;
   padding: 0;
+  flex-wrap: nowrap;
+  white-space: nowrap;
 }
 
 #main-nav li {
@@ -85,6 +90,7 @@ main {
   max-width: 1000px;
   margin: 0 auto;
   padding: 1rem;
+  flex: 1;
 }
 
 .hero {

--- a/technische-ondersteuning.html
+++ b/technische-ondersteuning.html
@@ -19,16 +19,7 @@
     </div>
     <nav id="main-nav">
       <div class="container">
-        <ul>
-          <li><a href="index.html">Home</a></li>
-          <li><a href="licht-geluid-op-locatie.html">Licht &amp; Geluid</a></li>
-          <li><a href="technische-ondersteuning.html">Technische Ondersteuning</a></li>
-          <li><a href="stroomvoorziening-op-locatie.html">Stroomvoorziening</a></li>
-          <li><a href="materiaal-verhuur.html">Materiaal Verhuur</a></li>
-          <li><a href="spoedservice.html">Spoedservice</a></li>
-          <li><a href="contact.html">Contact</a></li>
-          <li><a href="facebook.html">Facebook</a></li>
-        </ul>
+        <ul><li><a href="index.html">Home</a></li><li><a href="licht-geluid-op-locatie.html">Licht &amp; Geluid</a></li><li><a href="technische-ondersteuning.html">Technische Ondersteuning</a></li><li><a href="stroomvoorziening-op-locatie.html">Stroomvoorziening</a></li><li><a href="materiaal-verhuur.html">Materiaal Verhuur</a></li><li><a href="spoedservice.html">Spoedservice</a></li><li><a href="contact.html">Contact</a></li><li><a href="facebook.html">Facebook</a></li></ul>
       </div>
     </nav>
   </header>


### PR DESCRIPTION
## Summary
- force body to stretch the page so footer sticks to bottom
- make `main` grow to fill space
- keep nav bar links on a single line
- rewrite `<nav>` markup into a single line on every page

## Testing
- `tidy -errors index.html`
- `tidy -errors contact.html facebook.html licht-geluid-op-locatie.html materiaal-verhuur.html spoedservice.html stroomvoorziening-op-locatie.html technische-ondersteuning.html`


------
https://chatgpt.com/codex/tasks/task_e_6887da8f92b88332b540c100d57f80a0