### PR TITLE
Fix HTML font links

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -7,7 +7,7 @@
   <title>Contact - Gjaltema Producties</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet" />
   <link rel="icon" type="image/png" href="logo.png" />
   <link rel="stylesheet" href="style.css" />
 </head>

--- a/kerken.html
+++ b/kerken.html
@@ -6,7 +6,7 @@
   <meta name="description" content="Ondersteuning en apparatuur voor kerken">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
   <link rel="icon" type="image/png" href="logo.png">
   <link rel="stylesheet" href="style.css">
   <title>Kerken - Gjaltema Producties</title>

--- a/licht-geluid-op-locatie.html
+++ b/licht-geluid-op-locatie.html
@@ -6,7 +6,7 @@
   <meta name="description" content="Verjaardagsfeesten met licht en geluid van Gjaltema Producties">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
   <link rel="icon" type="image/png" href="logo.png">
   <link rel="stylesheet" href="style.css">
   <title>Verjaardag - Gjaltema Producties</title>

--- a/spoedservice.html
+++ b/spoedservice.html
@@ -6,7 +6,7 @@
   <meta name="description" content="Zakelijke evenementen en ondersteuning">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
   <link rel="icon" type="image/png" href="logo.png">
   <link rel="stylesheet" href="style.css">
   <title>Zakelijk - Gjaltema Producties</title>

--- a/stroomvoorziening-op-locatie.html
+++ b/stroomvoorziening-op-locatie.html
@@ -6,7 +6,7 @@
   <meta name="description" content="Oplossingen voor verenigingen en clubs">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
   <link rel="icon" type="image/png" href="logo.png">
   <link rel="stylesheet" href="style.css">
   <title>Verenigingen &amp; Clubs - Gjaltema Producties</title>

--- a/technische-ondersteuning.html
+++ b/technische-ondersteuning.html
@@ -6,7 +6,7 @@
   <meta name="description" content="Complete techniek voor feesttenten tot 500 man">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
   <link rel="icon" type="image/png" href="logo.png">
   <link rel="stylesheet" href="style.css">
   <title>Feesttenten tot 500 man - Gjaltema Producties</title>


### PR DESCRIPTION
## Summary
- correct Google Fonts URLs to escape `&`

## Testing
- `tidy -errors contact.html`
- `linkchecker index.html --check-extern --no-status`

------
https://chatgpt.com/codex/tasks/task_e_68889379f2888332bd0be49e85f3d303