### PR TITLE
Add subtle borders around sections

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,6 +1,6 @@
 body {
   font-family: 'Poppins', sans-serif;
-  background-color: #f9f9f9;
+  background-color: #fcfcfc;
   color: #222;
   margin: 0;
   line-height: 1.6;
@@ -127,6 +127,13 @@ main {
 
 section {
   margin-bottom: 2rem;
+}
+
+main > section:not(.hero) {
+  border: 1px solid #ddd;
+  padding: 1rem;
+  background-color: #fff;
+  border-radius: 6px;
 }
 
 .contact-form {


### PR DESCRIPTION
## Summary
- lighten page background
- outline content sections with a subtle grey border

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68889b65264883329baeeacfe6d6689e