### PR TITLE
Centralize header and footer

### DIFF
--- a/assets/includes/footer.html
+++ b/assets/includes/footer.html
@@ -1,0 +1,5 @@
+<footer>
+  <div class="container">
+    <p>Gjaltema Producties &bull; KvK 97624578 &bull; Kievitsweg 17a &bull; E-mail: nog niet bekend &bull; Telefoon: nog niet bekend</p>
+  </div>
+</footer>

--- a/assets/includes/header.html
+++ b/assets/includes/header.html
@@ -1,0 +1,18 @@
+<header>
+  <div class="container">
+    <img src="/assets/images/logo.png" alt="Gjaltema Producties" class="logo">
+    <nav id="main-nav">
+      <ul>
+        <li><a href="/index.html">Home</a></li>
+        <li><a href="/verjaardag/verjaardag.html">Verjaardag</a></li>
+        <li><a href="/feesttenten-tot-500-man/feesttenten-tot-500-man.html">Feesttenten tot 500 man</a></li>
+        <li><a href="/verenigingen-en-clubs/verenigingen-en-clubs.html">Verenigingen &amp; Clubs</a></li>
+        <li><a href="/kerken/kerken.html">Kerken</a></li>
+        <li><a href="/zakelijk/zakelijk.html">Zakelijk</a></li>
+        <li><a href="/contact/contact.html">Contact</a></li>
+        <li><a href="/facebook/facebook.html">Facebook</a></li>
+      </ul>
+    </nav>
+    <button class="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="main-nav">&#9776;</button>
+  </div>
+</header>

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,7 +1,21 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const toggle = document.querySelector('.menu-toggle');
-  const nav = document.querySelector('nav');
-  if (toggle && nav) {
+  const loadPartial = (selector, url) => {
+    const placeholder = document.querySelector(selector);
+    if (!placeholder) return Promise.resolve();
+    return fetch(url)
+      .then(r => r.text())
+      .then(html => { placeholder.outerHTML = html; });
+  };
+
+  Promise.all([
+    loadPartial('header', '/assets/includes/header.html'),
+    loadPartial('footer', '/assets/includes/footer.html')
+  ]).then(init);
+
+  function init() {
+    const toggle = document.querySelector('.menu-toggle');
+    const nav = document.querySelector('nav');
+    if (toggle && nav) {
     let lastScrollY = window.scrollY;
     const closeMenu = () => {
       nav.classList.remove('open');
@@ -82,4 +96,5 @@ document.addEventListener('DOMContentLoaded', () => {
         messageField.value = `Ik ben geïnteresseerd in pakket ${pakket}`;
       }
     }
-  });
+  }
+});

--- a/contact/contact.html
+++ b/contact/contact.html
@@ -8,20 +8,13 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet" />
-  <link rel="icon" type="image/png" href="../assets/images/logo.png" />
-  <link rel="stylesheet" href="../assets/css/style.css" />
+  <base href="/">
+  <link rel="icon" type="image/png" href="/assets/images/logo.png">
+  <link rel="stylesheet" href="/assets/css/style.css">
 </head>
 <body>
 
-  <header>
-    <div class="container">
-      <img src="../assets/images/logo.png" alt="Gjaltema Producties" class="logo">
-      <nav id="main-nav">
-        <ul><li><a href="../index.html">Home</a></li><li><a href="../verjaardag/verjaardag.html">Verjaardag</a></li><li><a href="../feesttenten-tot-500-man/feesttenten-tot-500-man.html">Feesttenten tot 500 man</a></li><li><a href="../verenigingen-en-clubs/verenigingen-en-clubs.html">Verenigingen &amp; Clubs</a></li><li><a href="../kerken/kerken.html">Kerken</a></li><li><a href="../zakelijk/zakelijk.html">Zakelijk</a></li><li><a href="../contact/contact.html">Contact</a></li><li><a href="../facebook/facebook.html">Facebook</a></li></ul>
-      </nav>
-      <button class="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="main-nav">&#9776;</button>
-    </div>
-  </header>
+  <header></header>
 
   <main class="container">
     <h1 data-text-src="text/header.txt"></h1>
@@ -40,17 +33,13 @@
       <textarea id="message" name="message" rows="5" required></textarea>
 
       <!-- redirect naar dezelfde pagina met ?success=1 -->
-      <input type="hidden" name="_redirect" value="https://richgjaltje.github.io/GjaltemaProducties/../contact/contact.html?success=1">
+      <input type="hidden" name="_redirect" value="https://richgjaltje.github.io/GjaltemaProducties/contact/contact.html?success=1">
 
       <button type="submit" class="btn">Verzenden</button>
     </form>
   </main>
 
-  <footer>
-    <div class="container">
-      <p>Gjaltema Producties • KvK 97624578 • Kievitsweg 17a • E-mail: nog niet bekend • Telefoon: nog niet bekend</p>
-    </div>
-  </footer>
+  <footer></footer>
 <a href="https://wa.me/31640041868" class="whatsapp-button" aria-label="Stuur ons een WhatsApp-bericht">
   <svg aria-hidden="true" viewBox="0 0 32 32" width="28" height="28" fill="currentColor">
     <path d="M16.001 2.369c7.484 0 13.531 6.047 13.531 13.531 0 2.371-0.604 4.686-1.749 6.735l1.931 6.636-6.869-1.8c-1.982 1.083-4.223 1.657-6.659 1.657-7.484 0-13.531-6.047-13.531-13.531 0-7.477 6.047-13.528 13.531-13.528zM16 0c-8.837 0-16 7.161-16 16 0 2.827 0.741 5.617 2.148 8.064l-2.148 7.936 7.112-1.859c2.357 1.284 5.029 1.958 7.888 1.958 8.837 0 16-7.161 16-16s-7.163-16.099-16-16.099z"></path>
@@ -58,6 +47,6 @@
   </svg>
 </a>
 
-  <script src="../assets/js/script.js"></script>
+  <script src="/assets/js/script.js"></script>
 </body>
 </html>

--- a/facebook/facebook.html
+++ b/facebook/facebook.html
@@ -7,20 +7,13 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/png" href="../assets/images/logo.png">
-  <link rel="stylesheet" href="../assets/css/style.css">
+  <base href="/">
+  <link rel="icon" type="image/png" href="/assets/images/logo.png">
+  <link rel="stylesheet" href="/assets/css/style.css">
   <title>Facebook - Gjaltema Producties</title>
 </head>
 <body>
-  <header>
-    <div class="container">
-      <img src="../assets/images/logo.png" alt="Gjaltema Producties" class="logo">
-      <nav id="main-nav">
-        <ul><li><a href="../index.html">Home</a></li><li><a href="../verjaardag/verjaardag.html">Verjaardag</a></li><li><a href="../feesttenten-tot-500-man/feesttenten-tot-500-man.html">Feesttenten tot 500 man</a></li><li><a href="../verenigingen-en-clubs/verenigingen-en-clubs.html">Verenigingen &amp; Clubs</a></li><li><a href="../kerken/kerken.html">Kerken</a></li><li><a href="../zakelijk/zakelijk.html">Zakelijk</a></li><li><a href="../contact/contact.html">Contact</a></li><li><a href="../facebook/facebook.html">Facebook</a></li></ul>
-      </nav>
-      <button class="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="main-nav">&#9776;</button>
-    </div>
-  </header>
+  <header></header>
 
   <main>
     <section class="hero">
@@ -34,11 +27,7 @@
     </section>
   </main>
 
-  <footer>
-    <div class="container">
-      <p>Gjaltema Producties &bull; KvK 97624578 &bull; Kievitsweg 17a &bull; E-mail: nog niet bekend &bull; Telefoon: nog niet bekend</p>
-    </div>
-  </footer>
+  <footer></footer>
 <a href="https://wa.me/31640041868" class="whatsapp-button" aria-label="Stuur ons een WhatsApp-bericht">
   <svg aria-hidden="true" viewBox="0 0 32 32" width="28" height="28" fill="currentColor">
     <path d="M16.001 2.369c7.484 0 13.531 6.047 13.531 13.531 0 2.371-0.604 4.686-1.749 6.735l1.931 6.636-6.869-1.8c-1.982 1.083-4.223 1.657-6.659 1.657-7.484 0-13.531-6.047-13.531-13.531 0-7.477 6.047-13.528 13.531-13.528zM16 0c-8.837 0-16 7.161-16 16 0 2.827 0.741 5.617 2.148 8.064l-2.148 7.936 7.112-1.859c2.357 1.284 5.029 1.958 7.888 1.958 8.837 0 16-7.161 16-16s-7.163-16.099-16-16.099z"></path>
@@ -46,7 +35,7 @@
   </svg>
 </a>
 
-  <script src="../assets/js/script.js"></script>
+  <script src="/assets/js/script.js"></script>
   <script async defer crossorigin="anonymous" src="https://connect.facebook.net/nl_NL/sdk.js#xfbml=1&amp;version=v18.0" nonce="gjaltema"></script>
 </body>
 </html>

--- a/feesttenten-tot-500-man/feesttenten-tot-500-man.html
+++ b/feesttenten-tot-500-man/feesttenten-tot-500-man.html
@@ -7,20 +7,13 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/png" href="../assets/images/logo.png">
-  <link rel="stylesheet" href="../assets/css/style.css">
+  <base href="/">
+  <link rel="icon" type="image/png" href="/assets/images/logo.png">
+  <link rel="stylesheet" href="/assets/css/style.css">
   <title>Feesttenten tot 500 man - Gjaltema Producties</title>
 </head>
 <body>
-  <header>
-    <div class="container">
-      <img src="../assets/images/logo.png" alt="Gjaltema Producties" class="logo">
-      <nav id="main-nav">
-        <ul><li><a href="../index.html">Home</a></li><li><a href="../verjaardag/verjaardag.html">Verjaardag</a></li><li><a href="../feesttenten-tot-500-man/feesttenten-tot-500-man.html">Feesttenten tot 500 man</a></li><li><a href="../verenigingen-en-clubs/verenigingen-en-clubs.html">Verenigingen &amp; Clubs</a></li><li><a href="../kerken/kerken.html">Kerken</a></li><li><a href="../zakelijk/zakelijk.html">Zakelijk</a></li><li><a href="../contact/contact.html">Contact</a></li><li><a href="../facebook/facebook.html">Facebook</a></li></ul>
-      </nav>
-      <button class="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="main-nav">&#9776;</button>
-    </div>
-  </header>
+  <header></header>
 
   <main class="container">
     <h1 data-text-src="text/title.txt"></h1>
@@ -30,11 +23,7 @@
     </section>
     </main>
 
-  <footer>
-    <div class="container">
-      <p>Gjaltema Producties &bull; KvK 97624578 &bull; Kievitsweg 17a &bull; E-mail: nog niet bekend &bull; Telefoon: nog niet bekend</p>
-    </div>
-  </footer>
+  <footer></footer>
 
   <a href="https://wa.me/31640041868" class="whatsapp-button" aria-label="Stuur ons een WhatsApp-bericht">
     <svg aria-hidden="true" viewBox="0 0 32 32" width="28" height="28" fill="currentColor">
@@ -43,6 +32,6 @@
     </svg>
   </a>
 
-  <script src="../assets/js/script.js"></script>
+  <script src="/assets/js/script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,20 +7,13 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/png" href="assets/images/logo.png">
-  <link rel="stylesheet" href="assets/css/style.css">
+  <base href="/">
+  <link rel="icon" type="image/png" href="/assets/images/logo.png">
+  <link rel="stylesheet" href="/assets/css/style.css">
   <title>Gjaltema Producties</title>
 </head>
 <body>
-  <header>
-    <div class="container">
-      <img src="assets/images/logo.png" alt="Gjaltema Producties" class="logo">
-      <nav id="main-nav">
-        <ul><li><a href="index.html">Home</a></li><li><a href="verjaardag/verjaardag.html">Verjaardag</a></li><li><a href="feesttenten-tot-500-man/feesttenten-tot-500-man.html">Feesttenten tot 500 man</a></li><li><a href="verenigingen-en-clubs/verenigingen-en-clubs.html">Verenigingen &amp; Clubs</a></li><li><a href="kerken/kerken.html">Kerken</a></li><li><a href="zakelijk/zakelijk.html">Zakelijk</a></li><li><a href="contact/contact.html">Contact</a></li><li><a href="facebook/facebook.html">Facebook</a></li></ul>
-      </nav>
-      <button class="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="main-nav">&#9776;</button>
-    </div>
-  </header>
+  <header></header>
 
   <main>
     <section class="hero">
@@ -40,17 +33,13 @@
 
   </main>
 
-  <footer>
-    <div class="container">
-      <p>Gjaltema Producties &bull; KvK 97624578 &bull; Kievitsweg 17a &bull; E-mail: nog niet bekend &bull; Telefoon: nog niet bekend</p>
-    </div>
-  </footer>
+  <footer></footer>
 <a href="https://wa.me/31640041868" class="whatsapp-button" aria-label="Stuur ons een WhatsApp-bericht">
   <svg aria-hidden="true" viewBox="0 0 32 32" width="28" height="28" fill="currentColor">
     <path d="M16.001 2.369c7.484 0 13.531 6.047 13.531 13.531 0 2.371-0.604 4.686-1.749 6.735l1.931 6.636-6.869-1.8c-1.982 1.083-4.223 1.657-6.659 1.657-7.484 0-13.531-6.047-13.531-13.531 0-7.477 6.047-13.528 13.531-13.528zM16 0c-8.837 0-16 7.161-16 16 0 2.827 0.741 5.617 2.148 8.064l-2.148 7.936 7.112-1.859c2.357 1.284 5.029 1.958 7.888 1.958 8.837 0 16-7.161 16-16s-7.163-16.099-16-16.099z"></path>
     <path d="M24.748 19.465c-0.375-0.187-2.222-1.098-2.567-1.222-0.345-0.132-0.599-0.187-0.853 0.187-0.246 0.368-0.981 1.222-1.203 1.467-0.222 0.248-0.444 0.279-0.819 0.095-0.375-0.187-1.584-0.584-3.018-1.863-1.117-0.999-1.871-2.229-2.089-2.604-0.218-0.375-0.023-0.577 0.165-0.764 0.168-0.167 0.37-0.436 0.555-0.654 0.184-0.218 0.246-0.372 0.37-0.621 0.122-0.249 0.061-0.466-0.03-0.653-0.095-0.186-0.853-2.057-1.168-2.822-0.309-0.743-0.623-0.642-0.853-0.653-0.222-0.012-0.476-0.012-0.73-0.012s-0.685 0.098-1.043 0.466c-0.354 0.368-1.36 1.329-1.36 3.242s1.392 3.756 1.586 4.015c0.184 0.248 2.737 4.187 6.629 5.866 0.927 0.401 1.652 0.639 2.219 0.818 0.933 0.295 1.781 0.253 2.451 0.154 0.748-0.111 2.222-0.904 2.537-1.775 0.312-0.871 0.312-1.616 0.218-1.775-0.089-0.161-0.335-0.248-0.705-0.436z"></path>
   </svg>
 </a>
-<script src="assets/js/script.js"></script>
+<script src="/assets/js/script.js"></script>
 </body>
 </html>

--- a/kerken/kerken.html
+++ b/kerken/kerken.html
@@ -7,20 +7,13 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/png" href="../assets/images/logo.png">
-  <link rel="stylesheet" href="../assets/css/style.css">
+  <base href="/">
+  <link rel="icon" type="image/png" href="/assets/images/logo.png">
+  <link rel="stylesheet" href="/assets/css/style.css">
   <title>Kerken - Gjaltema Producties</title>
 </head>
 <body>
-  <header>
-    <div class="container">
-      <img src="../assets/images/logo.png" alt="Gjaltema Producties" class="logo">
-      <nav id="main-nav">
-        <ul><li><a href="../index.html">Home</a></li><li><a href="../verjaardag/verjaardag.html">Verjaardag</a></li><li><a href="../feesttenten-tot-500-man/feesttenten-tot-500-man.html">Feesttenten tot 500 man</a></li><li><a href="../verenigingen-en-clubs/verenigingen-en-clubs.html">Verenigingen &amp; Clubs</a></li><li><a href="../kerken/kerken.html">Kerken</a></li><li><a href="../zakelijk/zakelijk.html">Zakelijk</a></li><li><a href="../contact/contact.html">Contact</a></li><li><a href="../facebook/facebook.html">Facebook</a></li></ul>
-      </nav>
-      <button class="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="main-nav">&#9776;</button>
-    </div>
-  </header>
+  <header></header>
 
   <main class="container">
     <h1 data-text-src="text/title.txt"></h1>
@@ -67,11 +60,7 @@
     </section>
   </main>
 
-  <footer>
-    <div class="container">
-      <p>Gjaltema Producties &bull; KvK 97624578 &bull; Kievitsweg 17a &bull; E-mail: nog niet bekend &bull; Telefoon: nog niet bekend</p>
-    </div>
-  </footer>
+  <footer></footer>
 
   <a href="https://wa.me/31640041868" class="whatsapp-button" aria-label="Stuur ons een WhatsApp-bericht">
     <svg aria-hidden="true" viewBox="0 0 32 32" width="28" height="28" fill="currentColor">
@@ -80,6 +69,6 @@
     </svg>
   </a>
 
-  <script src="../assets/js/script.js"></script>
+  <script src="/assets/js/script.js"></script>
 </body>
 </html>

--- a/verenigingen-en-clubs/verenigingen-en-clubs.html
+++ b/verenigingen-en-clubs/verenigingen-en-clubs.html
@@ -7,20 +7,13 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/png" href="../assets/images/logo.png">
-  <link rel="stylesheet" href="../assets/css/style.css">
+  <base href="/">
+  <link rel="icon" type="image/png" href="/assets/images/logo.png">
+  <link rel="stylesheet" href="/assets/css/style.css">
   <title>Verenigingen &amp; Clubs - Gjaltema Producties</title>
 </head>
 <body>
-  <header>
-    <div class="container">
-      <img src="../assets/images/logo.png" alt="Gjaltema Producties" class="logo">
-      <nav id="main-nav">
-        <ul><li><a href="../index.html">Home</a></li><li><a href="../verjaardag/verjaardag.html">Verjaardag</a></li><li><a href="../feesttenten-tot-500-man/feesttenten-tot-500-man.html">Feesttenten tot 500 man</a></li><li><a href="../verenigingen-en-clubs/verenigingen-en-clubs.html">Verenigingen &amp; Clubs</a></li><li><a href="../kerken/kerken.html">Kerken</a></li><li><a href="../zakelijk/zakelijk.html">Zakelijk</a></li><li><a href="../contact/contact.html">Contact</a></li><li><a href="../facebook/facebook.html">Facebook</a></li></ul>
-      </nav>
-      <button class="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="main-nav">&#9776;</button>
-    </div>
-  </header>
+  <header></header>
 
   <main class="container">
     <h1 data-text-src="text/title.txt"></h1>
@@ -68,11 +61,7 @@
     </section>
   </main>
 
-  <footer>
-    <div class="container">
-      <p>Gjaltema Producties &bull; KvK 97624578 &bull; Kievitsweg 17a &bull; E-mail: nog niet bekend &bull; Telefoon: nog niet bekend</p>
-    </div>
-  </footer>
+  <footer></footer>
 
   <a href="https://wa.me/31640041868" class="whatsapp-button" aria-label="Stuur ons een WhatsApp-bericht">
     <svg aria-hidden="true" viewBox="0 0 32 32" width="28" height="28" fill="currentColor">
@@ -81,6 +70,6 @@
     </svg>
   </a>
 
-  <script src="../assets/js/script.js"></script>
+  <script src="/assets/js/script.js"></script>
 </body>
 </html>

--- a/verjaardag/verjaardag.html
+++ b/verjaardag/verjaardag.html
@@ -7,20 +7,13 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/png" href="../assets/images/logo.png">
-  <link rel="stylesheet" href="../assets/css/style.css">
+  <base href="/">
+  <link rel="icon" type="image/png" href="/assets/images/logo.png">
+  <link rel="stylesheet" href="/assets/css/style.css">
   <title>Verjaardag - Gjaltema Producties</title>
 </head>
 <body>
-  <header>
-    <div class="container">
-      <img src="../assets/images/logo.png" alt="Gjaltema Producties" class="logo">
-      <nav id="main-nav">
-        <ul><li><a href="../index.html">Home</a></li><li><a href="../verjaardag/verjaardag.html">Verjaardag</a></li><li><a href="../feesttenten-tot-500-man/feesttenten-tot-500-man.html">Feesttenten tot 500 man</a></li><li><a href="../verenigingen-en-clubs/verenigingen-en-clubs.html">Verenigingen &amp; Clubs</a></li><li><a href="../kerken/kerken.html">Kerken</a></li><li><a href="../zakelijk/zakelijk.html">Zakelijk</a></li><li><a href="../contact/contact.html">Contact</a></li><li><a href="../facebook/facebook.html">Facebook</a></li></ul>
-      </nav>
-      <button class="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="main-nav">&#9776;</button>
-    </div>
-  </header>
+  <header></header>
 
     <main class="container">
       <h1 data-text-src="text/title.txt"></h1>
@@ -67,11 +60,7 @@
       </section>
   </main>
 
-  <footer>
-    <div class="container">
-      <p>Gjaltema Producties &bull; KvK 97624578 &bull; Kievitsweg 17a &bull; E-mail: nog niet bekend &bull; Telefoon: nog niet bekend</p>
-    </div>
-  </footer>
+  <footer></footer>
 
   <a href="https://wa.me/31640041868" class="whatsapp-button" aria-label="Stuur ons een WhatsApp-bericht">
     <svg aria-hidden="true" viewBox="0 0 32 32" width="28" height="28" fill="currentColor">
@@ -80,6 +69,6 @@
     </svg>
   </a>
 
-  <script src="../assets/js/script.js"></script>
+  <script src="/assets/js/script.js"></script>
 </body>
 </html>

--- a/zakelijk/zakelijk.html
+++ b/zakelijk/zakelijk.html
@@ -7,20 +7,13 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/png" href="../assets/images/logo.png">
-  <link rel="stylesheet" href="../assets/css/style.css">
+  <base href="/">
+  <link rel="icon" type="image/png" href="/assets/images/logo.png">
+  <link rel="stylesheet" href="/assets/css/style.css">
   <title>Zakelijk - Gjaltema Producties</title>
 </head>
 <body>
-  <header>
-    <div class="container">
-      <img src="../assets/images/logo.png" alt="Gjaltema Producties" class="logo">
-      <nav id="main-nav">
-        <ul><li><a href="../index.html">Home</a></li><li><a href="../verjaardag/verjaardag.html">Verjaardag</a></li><li><a href="../feesttenten-tot-500-man/feesttenten-tot-500-man.html">Feesttenten tot 500 man</a></li><li><a href="../verenigingen-en-clubs/verenigingen-en-clubs.html">Verenigingen &amp; Clubs</a></li><li><a href="../kerken/kerken.html">Kerken</a></li><li><a href="../zakelijk/zakelijk.html">Zakelijk</a></li><li><a href="../contact/contact.html">Contact</a></li><li><a href="../facebook/facebook.html">Facebook</a></li></ul>
-      </nav>
-      <button class="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="main-nav">&#9776;</button>
-    </div>
-  </header>
+  <header></header>
 
   <main class="container">
     <h1 data-text-src="text/title.txt"></h1>
@@ -84,11 +77,7 @@
     </section>
   </main>
 
-  <footer>
-    <div class="container">
-      <p>Gjaltema Producties &bull; KvK 97624578 &bull; Kievitsweg 17a &bull; E-mail: nog niet bekend &bull; Telefoon: nog niet bekend</p>
-    </div>
-  </footer>
+  <footer></footer>
 
   <a href="https://wa.me/31640041868" class="whatsapp-button" aria-label="Stuur ons een WhatsApp-bericht">
     <svg aria-hidden="true" viewBox="0 0 32 32" width="28" height="28" fill="currentColor">
@@ -97,6 +86,6 @@
     </svg>
   </a>
 
-  <script src="../assets/js/script.js"></script>
+  <script src="/assets/js/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- keep header and footer HTML snippets in `/assets/includes`
- fetch those snippets via JS for all pages
- update every page to load the shared header and footer

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6888b87918d48332b710faae2e6b96f6