### PR TITLE
Fix asset paths for subpages

### DIFF
--- a/assets/includes/header.html
+++ b/assets/includes/header.html
@@ -1,16 +1,16 @@
 <header>
   <div class="container">
-    <img src="/assets/images/logo.png" alt="Gjaltema Producties" class="logo">
+    <img src="assets/images/logo.png" alt="Gjaltema Producties" class="logo">
     <nav id="main-nav">
       <ul>
-        <li><a href="/index.html">Home</a></li>
-        <li><a href="/verjaardag/verjaardag.html">Verjaardag</a></li>
-        <li><a href="/feesttenten-tot-500-man/feesttenten-tot-500-man.html">Feesttenten tot 500 man</a></li>
-        <li><a href="/verenigingen-en-clubs/verenigingen-en-clubs.html">Verenigingen &amp; Clubs</a></li>
-        <li><a href="/kerken/kerken.html">Kerken</a></li>
-        <li><a href="/zakelijk/zakelijk.html">Zakelijk</a></li>
-        <li><a href="/contact/contact.html">Contact</a></li>
-        <li><a href="/facebook/facebook.html">Facebook</a></li>
+        <li><a href="index.html">Home</a></li>
+        <li><a href="verjaardag/verjaardag.html">Verjaardag</a></li>
+        <li><a href="feesttenten-tot-500-man/feesttenten-tot-500-man.html">Feesttenten tot 500 man</a></li>
+        <li><a href="verenigingen-en-clubs/verenigingen-en-clubs.html">Verenigingen &amp; Clubs</a></li>
+        <li><a href="kerken/kerken.html">Kerken</a></li>
+        <li><a href="zakelijk/zakelijk.html">Zakelijk</a></li>
+        <li><a href="contact/contact.html">Contact</a></li>
+        <li><a href="facebook/facebook.html">Facebook</a></li>
       </ul>
     </nav>
     <button class="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="main-nav">&#9776;</button>

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -8,8 +8,8 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   Promise.all([
-    loadPartial('header', '/assets/includes/header.html'),
-    loadPartial('footer', '/assets/includes/footer.html')
+    loadPartial('header', 'assets/includes/header.html'),
+    loadPartial('footer', 'assets/includes/footer.html')
   ]).then(init);
 
   function init() {

--- a/contact/contact.html
+++ b/contact/contact.html
@@ -8,9 +8,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet" />
-  <base href="/">
-  <link rel="icon" type="image/png" href="/assets/images/logo.png">
-  <link rel="stylesheet" href="/assets/css/style.css">
+  <base href="../">
+  <link rel="icon" type="image/png" href="assets/images/logo.png">
+  <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body>
 
@@ -47,6 +47,6 @@
   </svg>
 </a>
 
-  <script src="/assets/js/script.js"></script>
+  <script src="assets/js/script.js"></script>
 </body>
 </html>

--- a/facebook/facebook.html
+++ b/facebook/facebook.html
@@ -7,9 +7,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
-  <base href="/">
-  <link rel="icon" type="image/png" href="/assets/images/logo.png">
-  <link rel="stylesheet" href="/assets/css/style.css">
+  <base href="../">
+  <link rel="icon" type="image/png" href="assets/images/logo.png">
+  <link rel="stylesheet" href="assets/css/style.css">
   <title>Facebook - Gjaltema Producties</title>
 </head>
 <body>
@@ -35,7 +35,7 @@
   </svg>
 </a>
 
-  <script src="/assets/js/script.js"></script>
+  <script src="assets/js/script.js"></script>
   <script async defer crossorigin="anonymous" src="https://connect.facebook.net/nl_NL/sdk.js#xfbml=1&amp;version=v18.0" nonce="gjaltema"></script>
 </body>
 </html>

--- a/feesttenten-tot-500-man/feesttenten-tot-500-man.html
+++ b/feesttenten-tot-500-man/feesttenten-tot-500-man.html
@@ -7,9 +7,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
-  <base href="/">
-  <link rel="icon" type="image/png" href="/assets/images/logo.png">
-  <link rel="stylesheet" href="/assets/css/style.css">
+  <base href="../">
+  <link rel="icon" type="image/png" href="assets/images/logo.png">
+  <link rel="stylesheet" href="assets/css/style.css">
   <title>Feesttenten tot 500 man - Gjaltema Producties</title>
 </head>
 <body>
@@ -32,6 +32,6 @@
     </svg>
   </a>
 
-  <script src="/assets/js/script.js"></script>
+  <script src="assets/js/script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,9 +7,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
-  <base href="/">
-  <link rel="icon" type="image/png" href="/assets/images/logo.png">
-  <link rel="stylesheet" href="/assets/css/style.css">
+  <base href="./">
+  <link rel="icon" type="image/png" href="assets/images/logo.png">
+  <link rel="stylesheet" href="assets/css/style.css">
   <title>Gjaltema Producties</title>
 </head>
 <body>
@@ -40,6 +40,6 @@
     <path d="M24.748 19.465c-0.375-0.187-2.222-1.098-2.567-1.222-0.345-0.132-0.599-0.187-0.853 0.187-0.246 0.368-0.981 1.222-1.203 1.467-0.222 0.248-0.444 0.279-0.819 0.095-0.375-0.187-1.584-0.584-3.018-1.863-1.117-0.999-1.871-2.229-2.089-2.604-0.218-0.375-0.023-0.577 0.165-0.764 0.168-0.167 0.37-0.436 0.555-0.654 0.184-0.218 0.246-0.372 0.37-0.621 0.122-0.249 0.061-0.466-0.03-0.653-0.095-0.186-0.853-2.057-1.168-2.822-0.309-0.743-0.623-0.642-0.853-0.653-0.222-0.012-0.476-0.012-0.73-0.012s-0.685 0.098-1.043 0.466c-0.354 0.368-1.36 1.329-1.36 3.242s1.392 3.756 1.586 4.015c0.184 0.248 2.737 4.187 6.629 5.866 0.927 0.401 1.652 0.639 2.219 0.818 0.933 0.295 1.781 0.253 2.451 0.154 0.748-0.111 2.222-0.904 2.537-1.775 0.312-0.871 0.312-1.616 0.218-1.775-0.089-0.161-0.335-0.248-0.705-0.436z"></path>
   </svg>
 </a>
-<script src="/assets/js/script.js"></script>
+<script src="assets/js/script.js"></script>
 </body>
 </html>

--- a/kerken/kerken.html
+++ b/kerken/kerken.html
@@ -7,9 +7,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
-  <base href="/">
-  <link rel="icon" type="image/png" href="/assets/images/logo.png">
-  <link rel="stylesheet" href="/assets/css/style.css">
+  <base href="../">
+  <link rel="icon" type="image/png" href="assets/images/logo.png">
+  <link rel="stylesheet" href="assets/css/style.css">
   <title>Kerken - Gjaltema Producties</title>
 </head>
 <body>
@@ -69,6 +69,6 @@
     </svg>
   </a>
 
-  <script src="/assets/js/script.js"></script>
+  <script src="assets/js/script.js"></script>
 </body>
 </html>

--- a/verenigingen-en-clubs/verenigingen-en-clubs.html
+++ b/verenigingen-en-clubs/verenigingen-en-clubs.html
@@ -7,9 +7,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
-  <base href="/">
-  <link rel="icon" type="image/png" href="/assets/images/logo.png">
-  <link rel="stylesheet" href="/assets/css/style.css">
+  <base href="../">
+  <link rel="icon" type="image/png" href="assets/images/logo.png">
+  <link rel="stylesheet" href="assets/css/style.css">
   <title>Verenigingen &amp; Clubs - Gjaltema Producties</title>
 </head>
 <body>
@@ -70,6 +70,6 @@
     </svg>
   </a>
 
-  <script src="/assets/js/script.js"></script>
+  <script src="assets/js/script.js"></script>
 </body>
 </html>

--- a/verjaardag/verjaardag.html
+++ b/verjaardag/verjaardag.html
@@ -7,9 +7,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
-  <base href="/">
-  <link rel="icon" type="image/png" href="/assets/images/logo.png">
-  <link rel="stylesheet" href="/assets/css/style.css">
+  <base href="../">
+  <link rel="icon" type="image/png" href="assets/images/logo.png">
+  <link rel="stylesheet" href="assets/css/style.css">
   <title>Verjaardag - Gjaltema Producties</title>
 </head>
 <body>
@@ -69,6 +69,6 @@
     </svg>
   </a>
 
-  <script src="/assets/js/script.js"></script>
+  <script src="assets/js/script.js"></script>
 </body>
 </html>

--- a/zakelijk/zakelijk.html
+++ b/zakelijk/zakelijk.html
@@ -7,9 +7,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
-  <base href="/">
-  <link rel="icon" type="image/png" href="/assets/images/logo.png">
-  <link rel="stylesheet" href="/assets/css/style.css">
+  <base href="../">
+  <link rel="icon" type="image/png" href="assets/images/logo.png">
+  <link rel="stylesheet" href="assets/css/style.css">
   <title>Zakelijk - Gjaltema Producties</title>
 </head>
 <body>
@@ -86,6 +86,6 @@
     </svg>
   </a>
 
-  <script src="/assets/js/script.js"></script>
+  <script src="assets/js/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix asset paths for JS partial loader
- use relative URLs in header navigation
- set page base URLs for index and subpages

## Testing
- `python3 -m http.server 8000` (manual check via curl)

------
https://chatgpt.com/codex/tasks/task_e_6888c0431de88332bac625773c670d8a