### PR TITLE
Combine service info on Licht & Geluid page

### DIFF
--- a/advies-en-support/advies-en-support.html
+++ b/advies-en-support/advies-en-support.html
@@ -6,7 +6,7 @@
   <meta name="description" content="Technisch advies en ondersteuning">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <base href="../">
   <link rel="icon" type="image/png" href="assets/images/logo.png">
   <link rel="stylesheet" href="assets/css/style.css">
@@ -14,78 +14,20 @@
 </head>
 <body>
   <header></header>
-
   <main class="container">
-    <h1 data-text-src="advies-en-support/text/title.txt"></h1>
+    <h1>Advies &amp; Support</h1>
     <section>
       <img src="advies-en-support/spoedservice.jpg" alt="Advies en Support" class="service-photo">
-      <p data-text-src="advies-en-support/text/intro.txt"></p>
-    </section>
-
-    <section>
-      <h2 data-text-src="advies-en-support/text/presentatie-title.txt"></h2>
-        <p data-text-src="advies-en-support/text/presentatie-subtitle.txt"></p>
-        <p>Inbegrepen:</p>
-        <ul>
-          <li>2 speakers met heldere spraakversterking</li>
-          <li>1 draadloze microfoon (hand of dasspeld)</li>
-          <li>Compact mengpaneel</li>
-          <li>Installatie en test op locatie</li>
-          <li>Afbouw en ophalen</li>
-        </ul>
-        <p class="price-with-btn"><strong>Vanaf €195,-</strong> <a class="btn" href="contact/contact.html?pakket=Presentatiepakket">Aanvragen</a></p>
-    </section>
-
-    <section>
-      <h2 data-text-src="advies-en-support/text/bedrijfsfeest-title.txt"></h2>
-        <p data-text-src="advies-en-support/text/bedrijfsfeest-subtitle.txt"></p>
-        <p>Inbegrepen:</p>
-        <ul>
-          <li>Krachtige geluidsset met subwoofer</li>
-          <li>2 draadloze microfoons (voor toespraken of stukjes)</li>
-          <li>DJ booth met aansluiting voor eigen muziek of DJ</li>
-          <li>Basisset sfeerverlichting (klein)</li>
-          <li>Volledige installatie en afbouw</li>
-        </ul>
-        <p class="price-with-btn"><strong>Vanaf €375,-</strong> <a class="btn" href="contact/contact.html?pakket=Bedrijfsfeest">Aanvragen</a></p>
-    </section>
-
-    <section>
-      <h2 data-text-src="advies-en-support/text/evenement-title.txt"></h2>
-        <p data-text-src="advies-en-support/text/evenement-subtitle.txt"></p>
-        <p>Inbegrepen:</p>
-        <ul>
-          <li>Geluidsset voor grote ruimte of buitenlocatie</li>
-          <li>Meerdere microfoons (sprekers + interactie)</li>
-          <li>Sfeerverlichting of basislicht op het podium</li>
-          <li>Technisch advies vooraf en test op locatie</li>
-          <li>Stroomverdeling en veilige bekabeling</li>
-          <li>Optioneel: ondersteuning tijdens het evenement</li>
-        </ul>
-        <p class="price-with-btn"><strong>Vanaf €650,-</strong> <a class="btn" href="contact/contact.html?pakket=Evenement+of+productpresentatie">Aanvragen</a></p>
-    </section>
-
-    <section>
-      <h2 data-text-src="advies-en-support/text/extras-title.txt"></h2>
-        <ul>
-          <li>Beamer of groot scherm</li>
-          <li>Extra licht (kleurspots, moving heads)</li>
-          <li>Streamen of opnemen van presentaties</li>
-          <li>Technische hulp ter plaatse</li>
-        </ul>
-      <p data-text-src="advies-en-support/text/extras-subtitle.txt"></p>
+      <p>Heb je vragen over techniek of heb je snel hulp nodig bij een evenement? Binnenkort vind je hier tips, voorbeelden en handige ondersteuning voor elke situatie.</p>
     </section>
   </main>
-
   <footer></footer>
-
   <a href="https://wa.me/31640041868" class="whatsapp-button" aria-label="Stuur ons een WhatsApp-bericht">
     <svg aria-hidden="true" viewBox="0 0 32 32" width="28" height="28" fill="currentColor">
       <path d="M16.001 2.369c7.484 0 13.531 6.047 13.531 13.531 0 2.371-0.604 4.686-1.749 6.735l1.931 6.636-6.869-1.8c-1.982 1.083-4.223 1.657-6.659 1.657-7.484 0-13.531-6.047-13.531-13.531 0-7.477 6.047-13.528 13.531-13.528zM16 0c-8.837 0-16 7.161-16 16 0 2.827 0.741 5.617 2.148 8.064l-2.148 7.936 7.112-1.859c2.357 1.284 5.029 1.958 7.888 1.958 8.837 0 16-7.161 16-16s-7.163-16.099-16-16.099z"></path>
       <path d="M24.748 19.465c-0.375-0.187-2.222-1.098-2.567-1.222-0.345-0.132-0.599-0.187-0.853 0.187-0.246 0.368-0.981 1.222-1.203 1.467-0.222 0.248-0.444 0.279-0.819 0.095-0.375-0.187-1.584-0.584-3.018-1.863-1.117-0.999-1.871-2.229-2.089-2.604-0.218-0.375-0.023-0.577 0.165-0.764 0.168-0.167 0.37-0.436 0.555-0.654 0.184-0.218 0.246-0.372 0.37-0.621 0.122-0.249 0.061-0.466-0.03-0.653-0.095-0.186-0.853-2.057-1.168-2.822-0.309-0.743-0.623-0.642-0.853-0.653-0.222-0.012-0.476-0.012-0.73-0.012s-0.685 0.098-1.043 0.466c-0.354 0.368-1.36 1.329-1.36 3.242s1.392 3.756 1.586 4.015c0.184 0.248 2.737 4.187 6.629 5.866 0.927 0.401 1.652 0.639 2.219 0.818 0.933 0.295 1.781 0.253 2.451 0.154 0.748-0.111 2.222-0.904 2.537-1.775 0.312-0.871 0.312-1.616 0.218-1.775-0.089-0.161-0.335-0.248-0.705-0.436z"></path>
     </svg>
   </a>
-
   <script src="assets/js/script.js"></script>
 </body>
 </html>

--- a/eigen-producties/eigen-producties.html
+++ b/eigen-producties/eigen-producties.html
@@ -6,7 +6,7 @@
   <meta name="description" content="Eigen producties en speciale projecten">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <base href="../">
   <link rel="icon" type="image/png" href="assets/images/logo.png">
   <link rel="stylesheet" href="assets/css/style.css">
@@ -14,61 +14,20 @@
 </head>
 <body>
   <header></header>
-
   <main class="container">
-    <h1 data-text-src="eigen-producties/text/title.txt"></h1>
+    <h1>Eigen Producties</h1>
     <section>
       <img src="eigen-producties/materiaal-verhuur.jpg" alt="Eigen Producties" class="service-photo">
-      <p data-text-src="eigen-producties/text/intro.txt"></p>
-    </section>
-
-    <section>
-      <h2 data-text-src="eigen-producties/text/standaarddienst-title.txt"></h2>
-        <p data-text-src="eigen-producties/text/standaarddienst-subtitle.txt"></p>
-        <p>Inbegrepen:</p>
-        <ul>
-          <li>2 speakers geschikt voor spraak en zang</li>
-          <li>2 draadloze microfoons (hand- of dasspeld)</li>
-          <li>Installatie en geluidscheck op locatie</li>
-          <li>Afbouw en ophalen na afloop</li>
-        </ul>
-        <p class="price-with-btn"><strong>Vanaf €150,-</strong> <a class="btn" href="contact/contact.html?pakket=Standaarddienst">Aanvragen</a></p>
-    </section>
-
-    <section>
-      <h2 data-text-src="eigen-producties/text/uitgebreid-title.txt"></h2>
-        <p data-text-src="eigen-producties/text/uitgebreid-subtitle.txt"></p>
-        <p>Inbegrepen:</p>
-        <ul>
-          <li>Speakerset met voldoende vermogen voor grotere ruimtes</li>
-          <li>Meerdere microfoons voor zangers en instrumenten (bijv. zang, gitaar, piano)</li>
-          <li>Mixpaneel + kabels + monitoring</li>
-          <li>Opbouw, testmoment vooraf en afbouw door ons</li>
-          <li>Persoonlijke afstemming op locatie mogelijk</li>
-        </ul>
-        <p class="price-with-btn"><strong>Vanaf €275,-</strong> <a class="btn" href="contact/contact.html?pakket=Uitgebreid">Aanvragen</a></p>
-    </section>
-
-    <section>
-      <h2 data-text-src="eigen-producties/text/extra-opties-title.txt"></h2>
-        <ul>
-          <li>Sfeerverlichting voor avondvieringen of kerst</li>
-          <li>Advies bij problemen met bestaande geluidsinstallatie</li>
-          <li>Meedenken over microfoon- of versterkingskeuze</li>
-        </ul>
-      <p data-text-src="eigen-producties/text/extra-opties-subtitle.txt"></p>
+      <p>We werken aan inspirerende projecten en unieke concepten. Binnenkort lees je hier meer over onze eigen producties en de creatieve samenwerkingen waaraan we bouwen.</p>
     </section>
   </main>
-
   <footer></footer>
-
   <a href="https://wa.me/31640041868" class="whatsapp-button" aria-label="Stuur ons een WhatsApp-bericht">
     <svg aria-hidden="true" viewBox="0 0 32 32" width="28" height="28" fill="currentColor">
       <path d="M16.001 2.369c7.484 0 13.531 6.047 13.531 13.531 0 2.371-0.604 4.686-1.749 6.735l1.931 6.636-6.869-1.8c-1.982 1.083-4.223 1.657-6.659 1.657-7.484 0-13.531-6.047-13.531-13.531 0-7.477 6.047-13.528 13.531-13.528zM16 0c-8.837 0-16 7.161-16 16 0 2.827 0.741 5.617 2.148 8.064l-2.148 7.936 7.112-1.859c2.357 1.284 5.029 1.958 7.888 1.958 8.837 0 16-7.161 16-16s-7.163-16.099-16-16.099z"></path>
       <path d="M24.748 19.465c-0.375-0.187-2.222-1.098-2.567-1.222-0.345-0.132-0.599-0.187-0.853 0.187-0.246 0.368-0.981 1.222-1.203 1.467-0.222 0.248-0.444 0.279-0.819 0.095-0.375-0.187-1.584-0.584-3.018-1.863-1.117-0.999-1.871-2.229-2.089-2.604-0.218-0.375-0.023-0.577 0.165-0.764 0.168-0.167 0.37-0.436 0.555-0.654 0.184-0.218 0.246-0.372 0.37-0.621 0.122-0.249 0.061-0.466-0.03-0.653-0.095-0.186-0.853-2.057-1.168-2.822-0.309-0.743-0.623-0.642-0.853-0.653-0.222-0.012-0.476-0.012-0.73-0.012s-0.685 0.098-1.043 0.466c-0.354 0.368-1.36 1.329-1.36 3.242s1.392 3.756 1.586 4.015c0.184 0.248 2.737 4.187 6.629 5.866 0.927 0.401 1.652 0.639 2.219 0.818 0.933 0.295 1.781 0.253 2.451 0.154 0.748-0.111 2.222-0.904 2.537-1.775 0.312-0.871 0.312-1.616 0.218-1.775-0.089-0.161-0.335-0.248-0.705-0.436z"></path>
     </svg>
   </a>
-
   <script src="assets/js/script.js"></script>
 </body>
 </html>

--- a/licht-en-geluid/licht-en-geluid.html
+++ b/licht-en-geluid/licht-en-geluid.html
@@ -6,7 +6,7 @@
   <meta name="description" content="Diensten op het gebied van licht en geluid">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <base href="../">
   <link rel="icon" type="image/png" href="assets/images/logo.png">
   <link rel="stylesheet" href="assets/css/style.css">
@@ -14,61 +14,36 @@
 </head>
 <body>
   <header></header>
-
-    <main class="container">
-      <h1 data-text-src="licht-en-geluid/text/title.txt"></h1>
-      <section>
+  <main class="container">
+    <h1>Licht &amp; Geluid</h1>
+    <section>
       <img src="licht-en-geluid/Verjaardag.jpg" alt="Licht en Geluid" class="service-photo">
-        <p data-text-src="licht-en-geluid/text/intro.txt"></p>
-      </section>
-
-      <section>
-        <h2 data-text-src="licht-en-geluid/text/basisfeest-title.txt"></h2>
-        <p data-text-src="licht-en-geluid/text/basisfeest-subtitle.txt"></p>
-        <p>Inbegrepen:</p>
-        <ul>
-          <li>2 actieve speakers</li>
-          <li>1 draadloze microfoon</li>
-          <li>Bluetooth of aux-aansluiting voor je eigen muziek</li>
-          <li>Op- en afbouw op locatie</li>
-        </ul>
-        <p class="price-with-btn"><strong>Vanaf €175,-</strong> <a class="btn" href="contact/contact.html?pakket=Basisfeest">Aanvragen</a></p>
-      </section>
-
-      <section>
-        <h2 data-text-src="licht-en-geluid/text/feestavond-title.txt"></h2>
-        <p data-text-src="licht-en-geluid/text/feestavond-subtitle.txt"></p>
-        <p>Inbegrepen:</p>
-        <ul>
-          <li>Krachtige geluidsset met subwoofer</li>
-          <li>DJ booth met verlichting (zelf of eigen DJ)</li>
-          <li>2 microfoons (voor stukjes of zingen)</li>
-          <li>Sfeerverlichting voor binnen/buiten</li>
-          <li>Volledige installatie en afbouw</li>
-        </ul>
-        <p class="price-with-btn"><strong>Vanaf €325,-</strong> <a class="btn" href="contact/contact.html?pakket=Feestavond">Aanvragen</a></p>
-      </section>
-
-      <section>
-        <h2 data-text-src="licht-en-geluid/text/extra-opties-title.txt"></h2>
-        <ul>
-          <li>Rookmachine of lichteffecten</li>
-          <li>Extra microfoons of kabels</li>
-          <li>Langer huren (weekend i.p.v. 1 dag)</li>
-        </ul>
-        <p data-text-src="licht-en-geluid/text/extra-opties-subtitle.txt"></p>
-      </section>
+      <p>Of het nu gaat om een verenigingsactiviteit, kerkdienst of bedrijfsbijeenkomst, wij verzorgen de volledige techniek op het gebied van licht en geluid. Wij leveren, bouwen op en halen weer af, zodat jij nergens omkijken naar hebt.</p>
+    </section>
+    <section>
+      <h2>Basispakket – klein en betaalbaar</h2>
+      <p>Geschikt voor spraak en achtergrondmuziek tot ongeveer 100 personen.</p>
+      <p>Inbegrepen:</p>
+      <ul>
+        <li>2 speakers</li>
+        <li>2 draadloze microfoons</li>
+        <li>Aansluiting voor eigen muziek</li>
+        <li>Op- en afbouw op locatie</li>
+      </ul>
+      <p class="price-with-btn"><strong>Vanaf €150,-</strong> <a class="btn" href="contact/contact.html?pakket=Basispakket">Aanvragen</a></p>
+    </section>
+    <section>
+      <h2>Maatwerk voor grotere of bijzondere evenementen</h2>
+      <p>Voor uitgebreide feestavonden, kerkdiensten met band of zakelijke presentaties maken we graag een voorstel op maat. Neem contact op voor de mogelijkheden.</p>
+    </section>
   </main>
-
   <footer></footer>
-
   <a href="https://wa.me/31640041868" class="whatsapp-button" aria-label="Stuur ons een WhatsApp-bericht">
     <svg aria-hidden="true" viewBox="0 0 32 32" width="28" height="28" fill="currentColor">
       <path d="M16.001 2.369c7.484 0 13.531 6.047 13.531 13.531 0 2.371-0.604 4.686-1.749 6.735l1.931 6.636-6.869-1.8c-1.982 1.083-4.223 1.657-6.659 1.657-7.484 0-13.531-6.047-13.531-13.531 0-7.477 6.047-13.528 13.531-13.528zM16 0c-8.837 0-16 7.161-16 16 0 2.827 0.741 5.617 2.148 8.064l-2.148 7.936 7.112-1.859c2.357 1.284 5.029 1.958 7.888 1.958 8.837 0 16-7.161 16-16s-7.163-16.099-16-16.099z"></path>
       <path d="M24.748 19.465c-0.375-0.187-2.222-1.098-2.567-1.222-0.345-0.132-0.599-0.187-0.853 0.187-0.246 0.368-0.981 1.222-1.203 1.467-0.222 0.248-0.444 0.279-0.819 0.095-0.375-0.187-1.584-0.584-3.018-1.863-1.117-0.999-1.871-2.229-2.089-2.604-0.218-0.375-0.023-0.577 0.165-0.764 0.168-0.167 0.37-0.436 0.555-0.654 0.184-0.218 0.246-0.372 0.37-0.621 0.122-0.249 0.061-0.466-0.03-0.653-0.095-0.186-0.853-2.057-1.168-2.822-0.309-0.743-0.623-0.642-0.853-0.653-0.222-0.012-0.476-0.012-0.73-0.012s-0.685 0.098-1.043 0.466c-0.354 0.368-1.36 1.329-1.36 3.242s1.392 3.756 1.586 4.015c0.184 0.248 2.737 4.187 6.629 5.866 0.927 0.401 1.652 0.639 2.219 0.818 0.933 0.295 1.781 0.253 2.451 0.154 0.748-0.111 2.222-0.904 2.537-1.775 0.312-0.871 0.312-1.616 0.218-1.775-0.089-0.161-0.335-0.248-0.705-0.436z"></path>
     </svg>
   </a>
-
   <script src="assets/js/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- consolidate the content of the former service pages on `licht-en-geluid`
- reduce `eigen-producties` and `advies-en-support` to short placeholder texts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688903f841f4833283e32a41f6d3d34c