### PR TITLE
Place private events slideshow beside text and below header

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -325,28 +325,28 @@ footer {
   background-color: #333;
 }
 
-.particuliere-evenementen {
+.particuliere-content {
   display: flex;
   align-items: flex-start;
 }
 
-.particuliere-content {
+.particuliere-text {
   flex: 1;
   margin-right: 2rem;
 }
 
-.particuliere-evenementen .slideshow {
+.particuliere-content .slideshow {
   margin: 0;
 }
 
 @media (max-width: 767px) {
-  .particuliere-evenementen {
+  .particuliere-content {
     flex-direction: column;
   }
-  .particuliere-content {
+  .particuliere-text {
     margin-right: 0;
   }
-  .particuliere-evenementen .slideshow {
+  .particuliere-content .slideshow {
     margin-top: 1rem;
   }
 }

--- a/licht-en-geluid/licht-en-geluid.html
+++ b/licht-en-geluid/licht-en-geluid.html
@@ -24,19 +24,21 @@
     </section>
 
     <section class="particuliere-evenementen">
+      <h2>Particuliere evenementen</h2>
       <div class="particuliere-content">
-        <h2>Particuliere evenementen</h2>
-        <p>Of het nu gaat om een verjaardagsfeest, bruiloft, tuinfeest of jubileum – wij zorgen voor de techniek en ondersteuning die jouw evenement compleet maken.</p>
-        <p>We werken niet met standaardpakketten: elk evenement is uniek. Daarom overleggen we altijd persoonlijk, luisteren we naar jouw wensen en maken we een voorstel op maat. Zo weet je zeker dat alles technisch klopt én past bij de sfeer die jij voor ogen hebt.</p>
-        <p>Van kleine tuinfeesten tot complete feesttenten – wij denken graag met je mee en nemen het technische werk uit handen.</p>
-        <p class="price-with-btn">
-          <a class="btn" href="contact/contact.html?pakket=Basispakket">Contact opnemen</a>
-        </p>
-      </div>
-      <div id="particuliere-slideshow" class="slideshow">
-        <img class="slide-image" src="" alt="Slideshow afbeelding">
-        <p class="slide-caption"></p>
-        <div class="slideshow-dots"></div>
+        <div class="particuliere-text">
+          <p>Of het nu gaat om een verjaardagsfeest, bruiloft, tuinfeest of jubileum – wij zorgen voor de techniek en ondersteuning die jouw evenement compleet maken.</p>
+          <p>We werken niet met standaardpakketten: elk evenement is uniek. Daarom overleggen we altijd persoonlijk, luisteren we naar jouw wensen en maken we een voorstel op maat. Zo weet je zeker dat alles technisch klopt én past bij de sfeer die jij voor ogen hebt.</p>
+          <p>Van kleine tuinfeesten tot complete feesttenten – wij denken graag met je mee en nemen het technische werk uit handen.</p>
+          <p class="price-with-btn">
+            <a class="btn" href="contact/contact.html?pakket=Basispakket">Contact opnemen</a>
+          </p>
+        </div>
+        <div id="particuliere-slideshow" class="slideshow">
+          <img class="slide-image" src="" alt="Slideshow afbeelding">
+          <p class="slide-caption"></p>
+          <div class="slideshow-dots"></div>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Move the "Particuliere evenementen" heading outside the content container and wrap text in a new `.particuliere-text` div so the slideshow sits beside the text under the heading.
- Update CSS: make `.particuliere-content` a flex container and style `.particuliere-text` and slideshow for responsive layout.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f3fd4b0f08332846b9918e922f759