### PR TITLE
Align text and slideshow on light & sound page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -333,9 +333,11 @@ footer {
 .particuliere-text {
   flex: 1;
   margin-right: 2rem;
+  text-align: left;
 }
 
 .particuliere-content .slideshow {
+  flex: 1;
   margin: 0;
 }
 


### PR DESCRIPTION
## Summary
- Ensure private event description aligns to the left and slideshow to the right
- Explicitly left-align the event text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f40e011ec8332aa4dd2e4fafae60e