### PR TITLE
Add stroomvoorziening slideshow

### DIFF
--- a/assets/js/stroomvoorziening-slideshow.js
+++ b/assets/js/stroomvoorziening-slideshow.js
@@ -1,0 +1,58 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('stroomvoorziening-slideshow');
+  if (!container) return;
+
+  const imgEl = container.querySelector('.slide-image');
+  const captionEl = container.querySelector('.slide-caption');
+  const dotsContainer = container.querySelector('.slideshow-dots');
+
+  const slides = Array.from({ length: 4 }, (_, i) => ({
+    image: `stroomvoorziening/stroomvoorziening${i + 1}.jpg`,
+    text: `stroomvoorziening/slideshow/Slide_${i + 1}.txt`
+  }));
+
+  let index = 0;
+  let timer;
+
+  const updateDots = () => {
+    dotsContainer.querySelectorAll('.slideshow-dot').forEach((dot, i) => {
+      dot.classList.toggle('active', i === index);
+    });
+  };
+
+  const showSlide = i => {
+    index = (i + slides.length) % slides.length;
+    const slide = slides[index];
+    imgEl.src = slide.image;
+    fetch(slide.text)
+      .then(r => r.text())
+      .then(t => {
+        captionEl.textContent = t;
+      })
+      .catch(() => {
+        captionEl.textContent = '';
+      });
+    updateDots();
+  };
+
+  const startTimer = () => {
+    timer = setInterval(() => {
+      showSlide(index + 1);
+    }, 5000);
+  };
+
+  slides.forEach((_, i) => {
+    const dot = document.createElement('button');
+    dot.className = 'slideshow-dot';
+    dot.setAttribute('aria-label', `Ga naar slide ${i + 1}`);
+    dot.addEventListener('click', () => {
+      clearInterval(timer);
+      showSlide(i);
+      startTimer();
+    });
+    dotsContainer.appendChild(dot);
+  });
+
+  showSlide(0);
+  startTimer();
+});

--- a/stroomvoorziening/slideshow/Slide_1.txt
+++ b/stroomvoorziening/slideshow/Slide_1.txt
@@ -1,0 +1,1 @@
+Voorbeeld van onze robuuste stroomaggregaten in actie.

--- a/stroomvoorziening/slideshow/Slide_2.txt
+++ b/stroomvoorziening/slideshow/Slide_2.txt
@@ -1,0 +1,1 @@
+Onze gecertificeerde kabels zorgen voor veilige elektriciteit.

--- a/stroomvoorziening/slideshow/Slide_3.txt
+++ b/stroomvoorziening/slideshow/Slide_3.txt
@@ -1,0 +1,1 @@
+Wij leveren op maat gemaakte verdeelkasten voor elke situatie.

--- a/stroomvoorziening/slideshow/Slide_4.txt
+++ b/stroomvoorziening/slideshow/Slide_4.txt
@@ -1,0 +1,1 @@
+Professionele aansluiting en controle op locatie.

--- a/stroomvoorziening/stroomvoorziening.html
+++ b/stroomvoorziening/stroomvoorziening.html
@@ -21,6 +21,13 @@
       <img src="stroomvoorziening/technische-ondersteuning.jpg" alt="Stroomvoorziening" class="service-photo">
       <p data-text-src="stroomvoorziening/text/intro.txt"></p>
     </section>
+    <section>
+      <div id="stroomvoorziening-slideshow" class="slideshow">
+        <img class="slide-image" src="" alt="Stroomvoorziening afbeelding">
+        <p class="slide-caption"></p>
+        <div class="slideshow-dots"></div>
+      </div>
+    </section>
     </main>
 
   <footer></footer>
@@ -33,5 +40,6 @@
   </a>
 
   <script src="assets/js/script.js"></script>
+  <script src="assets/js/stroomvoorziening-slideshow.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate 4-image slideshow with captions on stroomvoorziening page
- load slide images and text via new stroomvoorziening-slideshow script
- add caption text files for each stroomvoorziening slide

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897af04e2988332ae3956ef4b4c17ef