### PR TITLE
Place stroomvoorziening slideshow beside intro text

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -325,6 +325,22 @@ footer {
   background-color: #333;
 }
 
+.stroomvoorziening-content {
+  display: flex;
+  align-items: flex-start;
+}
+
+.stroomvoorziening-text {
+  flex: 1;
+  margin-right: 2rem;
+  text-align: left;
+}
+
+.stroomvoorziening-content .slideshow {
+  flex: 1;
+  margin: 0;
+}
+
 .particuliere-content {
   display: flex;
   align-items: flex-start;
@@ -342,6 +358,15 @@ footer {
 }
 
 @media (max-width: 767px) {
+  .stroomvoorziening-content {
+    flex-direction: column;
+  }
+  .stroomvoorziening-text {
+    margin-right: 0;
+  }
+  .stroomvoorziening-content .slideshow {
+    margin-top: 1rem;
+  }
   .particuliere-content {
     flex-direction: column;
   }

--- a/stroomvoorziening/stroomvoorziening.html
+++ b/stroomvoorziening/stroomvoorziening.html
@@ -17,11 +17,10 @@
 
   <main class="container">
     <h1 data-text-src="stroomvoorziening/text/title.txt"></h1>
-    <section>
-      <img src="stroomvoorziening/technische-ondersteuning.jpg" alt="Stroomvoorziening" class="service-photo">
-      <p data-text-src="stroomvoorziening/text/intro.txt"></p>
-    </section>
-    <section>
+    <section class="stroomvoorziening-content">
+      <div class="stroomvoorziening-text">
+        <p data-text-src="stroomvoorziening/text/intro.txt"></p>
+      </div>
       <div id="stroomvoorziening-slideshow" class="slideshow">
         <img class="slide-image" src="" alt="Stroomvoorziening afbeelding">
         <p class="slide-caption"></p>


### PR DESCRIPTION
## Summary
- Remove hero photo and display stroomvoorziening intro text beside slideshow on desktop
- Add responsive CSS for side-by-side or stacked layout depending on screen width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897b0fbb7a08332a6636dc428c496c9