### PR TITLE
Swap navigation buttons for Eigen Producties and Advies en Vergunningen

### DIFF
--- a/assets/includes/header.html
+++ b/assets/includes/header.html
@@ -6,8 +6,8 @@
         <li><a href="index.html">Home</a></li>
         <li><a href="licht-en-geluid/licht-en-geluid.html">Licht &amp; Geluid</a></li>
         <li><a href="stroomvoorziening/stroomvoorziening.html">Stroomvoorziening</a></li>
-        <li><a href="eigen-producties/eigen-producties.html">Eigen Producties</a></li>
         <li><a href="advies-en-vergunningen/advies-en-vergunningen.html">Advies en Vergunningen</a></li>
+        <li><a href="eigen-producties/eigen-producties.html">Eigen Producties</a></li>
         <li><a href="contact/contact.html">Contact</a></li>
         <li><a href="facebook/facebook.html">Facebook</a></li>
       </ul>


### PR DESCRIPTION
## Summary
- Swap "Eigen Producties" and "Advies en Vergunningen" in the site navigation so that Advies en Vergunningen appears before Eigen Producties.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897b58e35cc8332b75439c61157a7b7