### PR TITLE
Add responsive service tiles on home page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -142,6 +142,43 @@ main ul {
   font-size: 1rem;
 }
 
+.services .tile-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+}
+
+.services .tile {
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  text-decoration: none;
+  color: inherit;
+}
+
+.services .tile img {
+  width: 100%;
+  height: auto;
+  border-radius: 6px;
+}
+
+.services .tile h3 {
+  margin: 0.5rem 0 0;
+  font-size: 1.1rem;
+}
+
+@media (min-width: 600px) {
+  .services .tile-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 900px) {
+  .services .tile-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
 .contact-form {
   display: flex;
   flex-direction: column;

--- a/index.html
+++ b/index.html
@@ -26,6 +26,28 @@
       <p data-text-src="assets/text/intro-2.txt"></p>
     </section>
 
+    <section class="services">
+      <h2>Diensten</h2>
+      <div class="tile-grid">
+        <a class="tile" href="licht-en-geluid/">
+          <img src="tegel_lichtengeluid.png" alt="Licht &amp; geluid">
+          <h3>Licht &amp; geluid</h3>
+        </a>
+        <a class="tile" href="stroomvoorziening/">
+          <img src="tegel_stroomvoorziening.png" alt="Stroomvoorziening">
+          <h3>Stroomvoorziening</h3>
+        </a>
+        <a class="tile" href="advies-en-vergunningen/">
+          <img src="tegel_adviesenvergunningen.png" alt="Advies en vergunningen">
+          <h3>Advies en vergunningen</h3>
+        </a>
+        <a class="tile" href="eigen-producties/">
+          <img src="tegel_eigenproducties.png" alt="Eigen producties">
+          <h3>Eigen producties</h3>
+        </a>
+      </div>
+    </section>
+
     <section id="over-ons">
       <h2>Over ons</h2>
       <p data-text-src="assets/text/about.txt"></p>


### PR DESCRIPTION
## Summary
- Add a services section with clickable tiles linking to key offerings
- Style tiles with a responsive grid for 1–3 columns depending on screen size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689907ffb7f883328bd39300e58701e4