### PR TITLE
Fix home page tiles navigation links

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,19 +29,19 @@
     <section class="services">
       <h2>Diensten</h2>
       <div class="tile-grid">
-        <a class="tile" href="licht-en-geluid/">
+        <a class="tile" href="licht-en-geluid/licht-en-geluid.html">
           <img src="tegel_lichtengeluid.png" alt="Licht &amp; geluid">
           <h3>Licht &amp; geluid</h3>
         </a>
-        <a class="tile" href="stroomvoorziening/">
+        <a class="tile" href="stroomvoorziening/stroomvoorziening.html">
           <img src="tegel_stroomvoorziening.png" alt="Stroomvoorziening">
           <h3>Stroomvoorziening</h3>
         </a>
-        <a class="tile" href="advies-en-vergunningen/">
+        <a class="tile" href="advies-en-vergunningen/advies-en-vergunningen.html">
           <img src="tegel_adviesenvergunningen.png" alt="Advies en vergunningen">
           <h3>Advies en vergunningen</h3>
         </a>
-        <a class="tile" href="eigen-producties/">
+        <a class="tile" href="eigen-producties/eigen-producties.html">
           <img src="tegel_eigenproducties.png" alt="Eigen producties">
           <h3>Eigen producties</h3>
         </a>


### PR DESCRIPTION
## Summary
- Ensure service tiles on the home page link directly to their respective pages.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68990a2ad21c8332af9d937981589de1