### PR TITLE
Home page intro uses hero text

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -97,12 +97,6 @@ main {
   flex: 1;
 }
 
-.hero {
-  text-align: center;
-  padding: 3rem 1rem;
-  background-color: #eef1f6;
-}
-
 .service-photo {
   display: block;
   max-width: 100%;
@@ -130,7 +124,7 @@ section {
   margin-bottom: 2rem;
 }
 
-main > section:not(.hero) {
+main > section {
   border: 1px solid #ddd;
   padding: 1rem;
   background-color: #fff;

--- a/index.html
+++ b/index.html
@@ -16,12 +16,9 @@
   <header></header>
 
   <main>
-    <section class="hero">
+    <section class="intro">
       <h1 data-text-src="assets/text/hero-title.txt"></h1>
       <h2 data-text-src="assets/text/hero-subtitle.txt"></h2>
-    </section>
-
-    <section class="intro">
       <p data-text-src="assets/text/intro-1.txt"></p>
       <p data-text-src="assets/text/intro-2.txt"></p>
     </section>


### PR DESCRIPTION
## Summary
- Remove grey hero section from the home page
- Move previous hero title and subtitle into the intro section
- Drop unused hero styles and apply generic styling to all sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899156b7b388332b9bd95363052a98d