### PR TITLE
Replace Facebook embed with link button

### DIFF
--- a/facebook/facebook.html
+++ b/facebook/facebook.html
@@ -22,8 +22,9 @@
     </section>
 
     <section>
-      <div id="fb-root"></div>
-      <div class="fb-page" data-href="https://www.facebook.com/gjaltemaproducties" data-tabs="timeline" data-width="500" data-height="700" data-small-header="false" data-adapt-container-width="true" data-hide-cover="false" data-show-facepile="true"><blockquote cite="https://www.facebook.com/gjaltemaproducties" class="fb-xfbml-parse-ignore"><a href="https://www.facebook.com/gjaltemaproducties">Gjaltema Producties</a></blockquote></div>
+      <a href="https://www.facebook.com/gjaltemaproducties" class="btn" target="_blank" rel="noopener">
+        Bezoek onze Facebookpagina
+      </a>
     </section>
   </main>
 
@@ -36,6 +37,5 @@
 </a>
 
   <script src="assets/js/script.js"></script>
-  <script async defer crossorigin="anonymous" src="https://connect.facebook.net/nl_NL/sdk.js#xfbml=1&amp;version=v18.0" nonce="gjaltema"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- simplify Facebook page by replacing embedded widget with a direct button link
- drop unused Facebook SDK script

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68992157d3bc83329bdd880e59152887