### PR TITLE
Stop automatische invulling contactformulier

### DIFF
--- a/advies-en-vergunningen/advies-en-vergunningen.html
+++ b/advies-en-vergunningen/advies-en-vergunningen.html
@@ -21,7 +21,7 @@
         <p>Heb je vragen over techniek of moet je vergunningen regelen voor jouw evenement? Wij ondersteunen met duidelijke adviezen en helpen bij het aanvragen van de benodigde vergunningen.</p>
       </section>
       <p class="price-with-btn">
-        <a class="btn" href="contact/contact.html?pakket=Advies%20en%20Vergunningen">Contact opnemen</a>
+        <a class="btn" href="contact/contact.html">Contact opnemen</a>
       </p>
     </main>
   <footer></footer>

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -88,13 +88,8 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
 
-    const messageField = document.getElementById('message');
-    if (messageField) {
-      const urlParams = new URLSearchParams(window.location.search);
-      const pakket = urlParams.get('pakket');
-      if (pakket) {
-        messageField.value = `Ik ben geïnteresseerd in pakket ${pakket}`;
-      }
-    }
+    // Voorheen werd het berichtveld automatisch ingevuld op basis van
+    // een "pakket"-queryparameter. Dat gedrag is verwijderd zodat het
+    // contactformulier niet langer vooraf ingevulde tekst bevat.
   }
 });

--- a/licht-en-geluid/licht-en-geluid.html
+++ b/licht-en-geluid/licht-en-geluid.html
@@ -31,7 +31,7 @@
           <p>We werken niet met standaardpakketten: elk evenement is uniek. Daarom overleggen we altijd persoonlijk, luisteren we naar jouw wensen en maken we een voorstel op maat. Zo weet je zeker dat alles technisch klopt én past bij de sfeer die jij voor ogen hebt.</p>
           <p>Van kleine tuinfeesten tot complete feesttenten – wij denken graag met je mee en nemen het technische werk uit handen.</p>
           <p class="price-with-btn">
-            <a class="btn" href="contact/contact.html?pakket=Basispakket">Contact opnemen</a>
+            <a class="btn" href="contact/contact.html">Contact opnemen</a>
           </p>
         </div>
         <div id="particuliere-slideshow" class="slideshow">
@@ -46,7 +46,7 @@
         <h2>Maatwerk voor grotere of bijzondere evenementen</h2>
         <p>Voor uitgebreide feestavonden, kerkdiensten met band of zakelijke presentaties verzorgen wij de complete technische productie. Denk aan professionele geluidsinstallaties, indrukwekkende lichtshows, op- en afbouw, maar ook livestream of opname van het evenement. We bespreken graag jouw wensen en maken een concreet plan dat perfect aansluit bij de locatie en het programma.</p>
         <p class="price-with-btn">
-          <a class="btn" href="contact/contact.html?pakket=Maatwerk">Contact opnemen</a>
+          <a class="btn" href="contact/contact.html">Contact opnemen</a>
         </p>
       </section>
   </main>

--- a/stroomvoorziening/stroomvoorziening.html
+++ b/stroomvoorziening/stroomvoorziening.html
@@ -28,7 +28,7 @@
       </div>
     </section>
     <p class="price-with-btn">
-      <a class="btn" href="contact/contact.html?pakket=Stroomvoorziening">Contact opnemen</a>
+      <a class="btn" href="contact/contact.html">Contact opnemen</a>
     </p>
     </main>
 


### PR DESCRIPTION
## Samenvatting
- Verwijdert de logica die het contactformulier automatisch invulde op basis van een `pakket`-parameter.
- Past contactknoppen aan zodat ze geen `pakket`-parameter meer meesturen.

## Testinstructies
- `npm test` (verwacht foutmelding; geen tests aanwezig)


------
https://chatgpt.com/codex/tasks/task_e_68aec72d4304833298934a3acbedf76c